### PR TITLE
Re-introduce the call to setup_logging

### DIFF
--- a/dropbox-upload/upload.py
+++ b/dropbox-upload/upload.py
@@ -138,6 +138,7 @@ def file_exists(dbx, file_path, dest_path):
 def main():
 
     config = load_config()
+    setup_logging(config)
     dropbox_dir = pathlib.Path(config["dropbox_dir"])
 
     LOG.info("Starting Snapshot backup")


### PR DESCRIPTION
This was lost when I done a slight refactor of the code. Whoops.

The addon should start to output a reasonable log again.

Closes #9