### PR TITLE
Don't allow use of "filename":"snapshot_name" with non-unique names

### DIFF
--- a/dropbox-upload/dropbox_upload/backup.py
+++ b/dropbox-upload/dropbox_upload/backup.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pathlib
+from collections import Counter
 
 import arrow
 
@@ -37,6 +38,17 @@ def backup(dbx, config, snapshots):
     if not snapshots:
         LOG.warning("No snapshots found to backup")
         return
+
+    if config["filename"] == "snapshot_name":
+        names = Counter(s["name"] for s in snapshots)
+        if len(names) < len(snapshots):
+            dupes = ", ".join(f'"{s[0]}"' for s in names.items() if s[1] > 0)
+            LOG.error(
+                "Snapshot names are not unique. This is incompatible saving "
+                "snapshots by name in Dropbox. Names used more than once: "
+                f"{dupes}"
+            )
+            return
 
     if config.get("keep") and len(snapshots) > config.get("keep"):
         LOG.info(f"Only backing up the first {config['keep']} snapshots")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -102,9 +102,21 @@ def test_backup_password_warning(cfg, dropbox_fake, snapshot_unprotected, caplog
     assert (
         "dropbox_upload.backup",
         logging.WARNING,
-        (
-            f"Snapshot '{snapshot_unprotected['name']}' is not password "
-            "protected. Always try to use passwords, particulary when "
-            "uploading all your data to a snapshot to a third party."
-        ),
+        f"Snapshot '{snapshot_unprotected['name']}' is not password "
+        "protected. Always try to use passwords, particulary when "
+        "uploading all your data to a snapshot to a third party.",
+    ) in caplog.record_tuples
+
+
+def test_backup_unique_name_check(cfg, snapshot, caplog):
+    caplog.set_level(logging.ERROR)
+    snapshots = [snapshot] * 3
+    cfg["filename"] = "snapshot_name"
+    backup.backup(None, cfg, snapshots)
+    assert (
+        "dropbox_upload.backup",
+        logging.ERROR,
+        "Snapshot names are not unique. This is incompatible saving snapshots "
+        "by name in Dropbox. Names used more than once: "
+        '"Automated Backup 2018-09-14"',
     ) in caplog.record_tuples


### PR DESCRIPTION
The process doesn't really work if we are uploading based on filename,
and the filename isn't unique.

The safest option is probably then to just drop out and error. We could
improve this in the future, but this change will prevent the addon
constantly re-uploading and overwriting snapshots in dropbox.

Related #40