### PR TITLE
🚑 Locks in architectures

### DIFF
--- a/dropbox-upload/config.json
+++ b/dropbox-upload/config.json
@@ -13,6 +13,12 @@
     "map": [
         "backup"
     ],
+    "arch": [
+      "aarch64",
+      "amd64",
+      "armhf",
+      "i386"
+    ],
     "options": {
         "access_token": "<YOUR_ACCESS_TOKEN>",
         "dropbox_dir": "/snapshots",


### PR DESCRIPTION
You don't have architectures listed, this will cause an issue real soon.
It already causes issues, since you don't ship armv7.

armv7 devices will fallback to armhf, so adding this prevents a lot of issues.

Fixes #49